### PR TITLE
기능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6-SNAPSHOT'
+	id 'fabric-loom' version '1.7-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,11 +5,11 @@ org.gradle.parallel=true
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 minecraft_version=1.21
-yarn_mappings=1.21+build.1
+yarn_mappings=1.21+build.2
 loader_version=0.15.11
 
 #Fabric api
-fabric_version=0.100.1+1.21
+fabric_version=0.100.3+1.21
 
 # Mod Properties
 mod_version = 1.3.7-1.21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/hyfata/najoan/koreanpatch/mixin/indicator/ChatScreenMixin.java
+++ b/src/main/java/com/hyfata/najoan/koreanpatch/mixin/indicator/ChatScreenMixin.java
@@ -1,23 +1,37 @@
 package com.hyfata.najoan.koreanpatch.mixin.indicator;
 
 import com.hyfata.najoan.koreanpatch.util.Indicator;
+import com.hyfata.najoan.koreanpatch.util.TextFieldWidgetUtil;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ChatScreen;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value={ChatScreen.class})
 public abstract class ChatScreenMixin extends Screen {
+
+    @Shadow private TextFieldWidget chatField;
+
+    private TextFieldWidgetUtil textFieldWidgetUtil;
+    private int width;
+
     protected ChatScreenMixin(Text title) {
         super(title);
     }
 
     @Inject(at = {@At(value="HEAD")}, method = {"render"})
     private void addCustomLabel(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-        Indicator.showIndicator(context, 2, this.height - 29, false);
+        textFieldWidgetUtil = new TextFieldWidgetUtil(chatField);
+        width = textFieldWidgetUtil.getTextWidth();
+        if (width >= client.getWindow().getWidth()) {
+            width = client.getWindow().getWidth();
+        }
+        Indicator.showIndicator(context, width + 2, this.height - 27, false);
     }
 }

--- a/src/main/java/com/hyfata/najoan/koreanpatch/mixin/indicator/ChatScreenMixin.java
+++ b/src/main/java/com/hyfata/najoan/koreanpatch/mixin/indicator/ChatScreenMixin.java
@@ -27,7 +27,9 @@ public abstract class ChatScreenMixin extends Screen {
 
     @Inject(at = {@At(value="HEAD")}, method = {"render"})
     private void addCustomLabel(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-        textFieldWidgetUtil = new TextFieldWidgetUtil(chatField);
+        if (textFieldWidgetUtil == null) {
+            textFieldWidgetUtil = new TextFieldWidgetUtil(chatField);
+        }
         if (width != textFieldWidgetUtil.getTextWidth()) {
             width = textFieldWidgetUtil.getTextWidth();
             if (width > client.getWindow().getWidth()) {

--- a/src/main/java/com/hyfata/najoan/koreanpatch/mixin/indicator/ChatScreenMixin.java
+++ b/src/main/java/com/hyfata/najoan/koreanpatch/mixin/indicator/ChatScreenMixin.java
@@ -19,7 +19,7 @@ public abstract class ChatScreenMixin extends Screen {
     @Shadow private TextFieldWidget chatField;
 
     private TextFieldWidgetUtil textFieldWidgetUtil;
-    private int width;
+    private int width = 0;
 
     protected ChatScreenMixin(Text title) {
         super(title);
@@ -28,9 +28,11 @@ public abstract class ChatScreenMixin extends Screen {
     @Inject(at = {@At(value="HEAD")}, method = {"render"})
     private void addCustomLabel(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         textFieldWidgetUtil = new TextFieldWidgetUtil(chatField);
-        width = textFieldWidgetUtil.getTextWidth();
-        if (width >= client.getWindow().getWidth()) {
-            width = client.getWindow().getWidth();
+        if (width != textFieldWidgetUtil.getTextWidth()) {
+            width = textFieldWidgetUtil.getTextWidth();
+            if (width > client.getWindow().getWidth()) {
+                width = client.getWindow().getWidth();
+            }
         }
         Indicator.showIndicator(context, width + 2, this.height - 27, false);
     }

--- a/src/main/java/com/hyfata/najoan/koreanpatch/mixin/indicator/ChatScreenMixin.java
+++ b/src/main/java/com/hyfata/najoan/koreanpatch/mixin/indicator/ChatScreenMixin.java
@@ -17,7 +17,7 @@ public abstract class ChatScreenMixin extends Screen {
     }
 
     @Inject(at = {@At(value="HEAD")}, method = {"render"})
-    private void addCustomLabel(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci){
-        Indicator.showIndicator(context, 2, this.height - 39, false);
+    private void addCustomLabel(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        Indicator.showIndicator(context, 2, this.height - 29, false);
     }
 }

--- a/src/main/java/com/hyfata/najoan/koreanpatch/util/Indicator.java
+++ b/src/main/java/com/hyfata/najoan/koreanpatch/util/Indicator.java
@@ -7,28 +7,47 @@ import net.minecraft.text.Text;
 
 public class Indicator {
     static MinecraftClient client = MinecraftClient.getInstance();
-    static Text KOREAN = Text.literal("한");
-    static Text ENGLISH = Text.literal("영");
+    static Text KOREAN = Text.translatable("koreanpatch.langtype.korean");
+    static Text ENGLISH = Text.translatable("koreanpatch.langtype.english");
 
     public static void showIndicator(DrawContext context, int x, int y, boolean center) {
+        int rgb = 0x000000;
+        int textOpacity = 50 * 255/100; // N% * (0 to 255)/100, default 50%
+        int backgroundColor = ((textOpacity & 0xFF) << 24) | rgb;
+
+        int frameColor;
+        int len;
+        Text lang;
+
+        if (KoreanPatchClient.KOREAN) {
+            lang = KOREAN;
+            len = 2 + client.textRenderer.getWidth(lang);
+            frameColor = -65536;
+        } else {
+            lang = ENGLISH;
+            len = 2 + client.textRenderer.getWidth(lang);
+            frameColor = -16711936;
+        }
+
         if (center) {
-            x -= 6;
+            x -= len / 2;
             y -= 2;
         }
 
-        if (KoreanPatchClient.KOREAN) {
-            context.fill(x, y, x+12, y+12, -65536);
-            context.fill(x+1, y+1, x+11, y+11, -16777216);
-            drawCenteredText(context, KOREAN, x+6, y+2);
-        }
-        else {
-            context.fill(x, y, x+12, y+12, -16711936);
-            context.fill(x+1, y+1, x+11, y+11, -16777216);
-            drawCenteredText(context, ENGLISH, x+6, y+2);
-        }
+        drawLabel(context, x+1 -1, y+1 -1, x+len+1 +1, y+1+10 +1, frameColor, backgroundColor);
+        drawCenteredText(context, lang, x+len/2 +1, y+1 +1);
     }
 
     private static void drawCenteredText(DrawContext context, Text text, int x, int y) {
         context.drawText(client.textRenderer, text, x - client.textRenderer.getWidth(text) / 2, y, -1, false);
+    }
+
+    private static void drawLabel(DrawContext context, int x1, int y1, int x2, int y2, int frameColor, int backgroundColor) {
+        context.fill(x1, y1, x2, y1+1, frameColor); // frame with fixed axis-y1
+        context.fill(x1, y2, x2, y2-1, frameColor); // frame with fixed axis-y2
+        context.fill(x1, y1, x1+1, y2, frameColor); // frame with fixed axis-x1
+        context.fill(x2, y1, x2-1, y2, frameColor); // frame with fixed axis-x2
+
+        context.fill(x1+1, y1+1, x2, y2, backgroundColor); // Background
     }
 }

--- a/src/main/java/com/hyfata/najoan/koreanpatch/util/TextFieldWidgetUtil.java
+++ b/src/main/java/com/hyfata/najoan/koreanpatch/util/TextFieldWidgetUtil.java
@@ -1,0 +1,20 @@
+package com.hyfata.najoan.koreanpatch.util;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import org.spongepowered.asm.mixin.Unique;
+
+public class TextFieldWidgetUtil {
+    @Unique
+    static MinecraftClient client = MinecraftClient.getInstance();
+    private final TextFieldWidget textFieldWidget;
+
+    public TextFieldWidgetUtil(TextFieldWidget textFieldWidget) {
+        this.textFieldWidget = textFieldWidget;
+    }
+
+    public int getTextWidth() {
+        String text = this.textFieldWidget.getText();
+        return client.textRenderer.getWidth(text);
+    }
+}

--- a/src/main/resources/assets/koreanpatch/lang/en_us.json
+++ b/src/main/resources/assets/koreanpatch/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+    "koreanpatch.langtype.english": "En",
+    "koreanpatch.langtype.korean": "Ko"
+}

--- a/src/main/resources/assets/koreanpatch/lang/ko_kr.json
+++ b/src/main/resources/assets/koreanpatch/lang/ko_kr.json
@@ -1,0 +1,4 @@
+{
+    "koreanpatch.langtype.english": "영어",
+    "koreanpatch.langtype.korean": "한글"
+}


### PR DESCRIPTION
- Gradle, Loom 업데이트
- 인디케이터 개선
- 챗 스크린 인디케이터 위치 수정
- 챗 스크린에 텍스트 길이에 따라 위치하는 인디케이터 추가 (개선 필요. client.getWindow().getWidth()보다 텍스트가 길 경우 인디케이터와 텍스트 커서 위치가 일치하지 않음. 이 항목에 대해서는 버그가 있을 수 있음. [b87c7c6](https://github.com/najoan125/fabric-koreanchat/pull/6/commits/b87c7c652f0c3ad41cbaa43415579c2bae70a4f3), [1f12ca3](https://github.com/najoan125/fabric-koreanchat/pull/6/commits/1f12ca38325f8dc9e6e88a7e4d4dd63447a428c5), [66aaef8](https://github.com/najoan125/fabric-koreanchat/pull/6/commits/66aaef84d8e984625be9ee7812d7c102424a3c5b) 커밋에 대하여.)