### PR TITLE
Fix locating obfuscation mapping for @Shadow field warning

### DIFF
--- a/src/main/java/com/hyfata/najoan/koreanpatch/mixin/mods/commandblockide/MultilineTextFieldWidgetMixin.java
+++ b/src/main/java/com/hyfata/najoan/koreanpatch/mixin/mods/commandblockide/MultilineTextFieldWidgetMixin.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(MultilineTextFieldWidget.class)
+@Mixin(value = MultilineTextFieldWidget.class, remap = false)
 public abstract class MultilineTextFieldWidgetMixin extends TextFieldWidget implements ITextFieldWidgetAccessor {
     public MultilineTextFieldWidgetMixin(TextRenderer textRenderer, int width, int height, Text text) {
         super(textRenderer, width, height, text);

--- a/src/main/java/com/hyfata/najoan/koreanpatch/mixin/mods/commandblockide/indicator/CommandBlockEditorMixin.java
+++ b/src/main/java/com/hyfata/najoan/koreanpatch/mixin/mods/commandblockide/indicator/CommandBlockEditorMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(CommandBlockEditor.class)
+@Mixin(value = CommandBlockEditor.class, remap = false)
 public abstract class CommandBlockEditorMixin extends CommandEditor {
     @Shadow
     @Final

--- a/src/main/java/com/hyfata/najoan/koreanpatch/mixin/mods/commandblockide/indicator/CommandEditorMixin.java
+++ b/src/main/java/com/hyfata/najoan/koreanpatch/mixin/mods/commandblockide/indicator/CommandEditorMixin.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(CommandEditor.class)
+@Mixin(value = CommandEditor.class, remap = false)
 public abstract class CommandEditorMixin {
     @Shadow
     @Final

--- a/src/main/java/com/hyfata/najoan/koreanpatch/mixin/mods/modmenu/ModMenuScreenMixin.java
+++ b/src/main/java/com/hyfata/najoan/koreanpatch/mixin/mods/modmenu/ModMenuScreenMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(ModsScreen.class)
+@Mixin(value = ModsScreen.class, remap = false)
 public class ModMenuScreenMixin {
     @Shadow
     private TextFieldWidget searchBox;


### PR DESCRIPTION
Fix

```
> Configure project :
Fabric Loom: 1.7.3
:remapping 49 mods from modImplementation (java-api)
:remapping 2 mods from modCompileOnly (java-api)
/home/runner/work/fabric-koreanchat/fabric-koreanchat/src/main/java/com/hyfata/najoan/koreanpatch/mixin/mods/commandblockide/indicator/CommandEditorMixin.java:20: warning: Unable to locate obfuscation mapping for @Shadow field

    @Shadow
    ^
/home/runner/work/fabric-koreanchat/fabric-koreanchat/src/main/java/com/hyfata/najoan/koreanpatch/mixin/mods/commandblockide/indicator/CommandEditorMixin.java:[24](https://github.com/najoan125/fabric-koreanchat/actions/runs/10213645917/job/28259454022#step:6:25): warning: Unable to locate obfuscation mapping for @Shadow field
    @Shadow
    ^
> Task :compileJava
2 warnings
```